### PR TITLE
Make post-provision resource depend on the EKS module

### DIFF
--- a/eks_cluster/main.tf
+++ b/eks_cluster/main.tf
@@ -38,6 +38,8 @@ module "eks" {
 }
 
 resource "null_resource" "post-provision" {
+  depends_on = ["module.eks"]
+
   # configure cluster, install Helm
   provisioner "local-exec" {
     command = <<EOF


### PR DESCRIPTION
Mistakenly I believed that the post-provisioning step (where Helm is installed) didn't occur until after the `eks` module had finished; however, a closer look at the Terraform output showed that the post-provisioning resource was executed at the very start of the apply, when the kubeconfig file would certainly not have been created yet.

This change simply adds `depends_on = ["module.eks"]` to the resource responsible for installing Helm. It means that the resource won't be executed until after everything from the EKS module has been wrapped up, which includes the kubeconfig file.

It should be noted that it's possible for the apply to fail because the EKS cluster takes too long to come up and Terraform times out after 15m of waiting for the cluster to be ready. In such an event, re-running `terraform apply` should work, and the Helm provisioning step will complete afterwards.